### PR TITLE
suit/v4: fix container entry and exit inconsistency

### DIFF
--- a/sys/suit/v4/cbor.c
+++ b/sys/suit/v4/cbor.c
@@ -182,7 +182,7 @@ static int _v4_parse(suit_v4_manifest_t *manifest, const uint8_t *buf,
         }
     }
 
-    cbor_value_leave_container(&map, &it);
+    cbor_value_leave_container(&it, &map);
 
     return SUIT_OK;
 }

--- a/sys/suit/v4/cbor.c
+++ b/sys/suit/v4/cbor.c
@@ -41,12 +41,12 @@ static suit_manifest_handler_t _manifest_get_auth_wrapper_handler(int key);
 
 int cbor_map_iterate_init(CborValue *map, CborValue *it)
 {
-    if (!cbor_value_is_map(it)) {
+    if (!cbor_value_is_map(map)) {
         LOG_INFO("suit_v4_parse(): manifest not an map\n)");
         return SUIT_ERR_INVALID_MANIFEST;
     }
 
-    cbor_value_enter_container(it, map);
+    cbor_value_enter_container(map, it);
 
     return SUIT_OK;
 }
@@ -161,7 +161,7 @@ static int _v4_parse(suit_v4_manifest_t *manifest, const uint8_t *buf,
 
     LOG_INFO("jumping into map\n)");
 
-    while (cbor_map_iterate(&map, &key, &value)) {
+    while (cbor_map_iterate(&it, &key, &value)) {
         int integer_key;
         if (suit_cbor_get_int(&key, &integer_key) != SUIT_OK){
             return SUIT_ERR_INVALID_MANIFEST;
@@ -182,7 +182,7 @@ static int _v4_parse(suit_v4_manifest_t *manifest, const uint8_t *buf,
         }
     }
 
-    cbor_value_leave_container(&it, &map);
+    cbor_value_leave_container(&map, &it);
 
     return SUIT_OK;
 }

--- a/sys/suit/v4/handlers.c
+++ b/sys/suit/v4/handlers.c
@@ -423,7 +423,7 @@ static int _component_handler(suit_v4_manifest_t *manifest, int key,
     }
 
     manifest->state |= SUIT_MANIFEST_HAVE_COMPONENTS;
-    cbor_value_enter_container(&arr, it);
+    cbor_value_enter_container(it, &arr);
 
     LOG_INFO("storing components done\n)");
     return 0;

--- a/sys/suit/v4/handlers.c
+++ b/sys/suit/v4/handlers.c
@@ -389,7 +389,7 @@ static int _component_handler(suit_v4_manifest_t *manifest, int key,
             return SUIT_ERR_INVALID_MANIFEST;
         }
 
-        cbor_map_iterate_init(&map, &arr);
+        cbor_map_iterate_init(&arr, &map);
 
         suit_v4_component_t *current = &manifest->components[n];
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR fix a bug that shows up when optimization is disabled (DEVELHELP=1) where the wrong CBOR container and iterator are exited or entered in suit/v4/cbor and suit/v4/handlers/. With optimization enabled some of the pointers are optimized our so this error doesn't show up.

It also cleans-up cbor_map_iterate and cbor_map_iterate_init to uniformize variable order and naming.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Follow examples/suit_update [README](https://github.com/future-proof-iot/RIOT/blob/suit/examples/suit_update/README.md) instructions but setting `DEVELHELP=1`.

When updating the device the procedure will fail on tinycbor related asserts when exiting the manifest and when verifying the digest do to inconsistencies that are optimized our when `DEVELHELP=0`.

#### Without this pr:

```
)component 0 parsed
0x1084d
*** RIOT kernel panic:
FAILED ASSERTION.

*** halted.

lost serial connection.
Cleaning up...
```

#### With this pr:

Update proceeds with no issue.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
