### PR TITLE
makefiles/suit: increase SOCK_URLPATH_MAXLEN

### DIFF
--- a/makefiles/suit.v4.inc.mk
+++ b/makefiles/suit.v4.inc.mk
@@ -10,6 +10,9 @@ SUIT_MANIFEST_LATEST ?= $(BINDIR_APP)-riot.suitv4.latest.bin
 SUIT_MANIFEST_SIGNED ?= $(BINDIR_APP)-riot.suitv4_signed.$(APP_VER).bin
 SUIT_MANIFEST_SIGNED_LATEST ?= $(BINDIR_APP)-riot.suitv4_signed.latest.bin
 
+# Long manifest names require more buffer space when parsing
+export CFLAGS += -DSOCK_URLPATH_MAXLEN=128
+
 SUIT_VENDOR ?= "riot-os.org"
 SUIT_SEQNR ?= $(APP_VER)
 SUIT_DEVICE_ID ?= $(BOARD)

--- a/sys/include/net/sock/util.h
+++ b/sys/include/net/sock/util.h
@@ -99,13 +99,30 @@ bool sock_udp_ep_equal(const sock_udp_ep_t *a, const sock_udp_ep_t *b);
  * @name helper definitions
  * @{
  */
-#define SOCK_SCHEME_MAXLEN      (16U)   /**< maximum length of the scheme part
-                                             for sock_urlsplit. Ensures a hard
-                                             limit on the string iterator */
-#define SOCK_HOSTPORT_MAXLEN    (64U)   /**< maximum length of host:port part for
-                                             sock_urlsplit() */
-#define SOCK_URLPATH_MAXLEN     (64U)   /**< maximum length path for
-                                             sock_urlsplit() */
+
+/**
+ * @brief maximum length of the scheme part for sock_urlsplit.
+ *
+ * Ensures a hard limit on the string iterator
+ * */
+#ifndef SOCK_SCHEME_MAXLEN
+#define SOCK_SCHEME_MAXLEN      (16U)
+#endif
+
+/**
+ * @brief maximum length of host:port part for sock_urlsplit()
+ */
+#ifndef SOCK_HOSTPORT_MAXLEN
+#define SOCK_HOSTPORT_MAXLEN    (64U)
+#endif
+
+/**
+ * @brief maximum length path for sock_urlsplit()
+ */
+#ifndef SOCK_URLPATH_MAXLEN
+#define SOCK_URLPATH_MAXLEN     (64U)
+#endif
+
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR makes `sys/net/sock/util.h` variables configurable and with this we can redefine SOCK_URLPATH_MAXLEN at compilation time to increase it when the naming for the URL file extension is too large.

### Testing procedure

in `makefiles/suit.v4.inc.mk` modify naming of `SUIT_MANIFEST_SIGNED_LATEST ?= $(BINDIR_APP)-riot.suitv4_signed.latest.bin`.

Follow [README](https://github.com/future-proof-iot/RIOT/blob/suit-dev/examples/suit_update/README.md)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Fixes #9 