### PR TITLE
[RIOT-fp] Improve keys generation targets

### DIFF
--- a/examples/suit_update/README.md
+++ b/examples/suit_update/README.md
@@ -38,17 +38,7 @@ You will get this message in the terminal:
 
     the public key is b'a0fc7fe714d0c81edccc50c9e3d9e6f9c72cc68c28990f235ede38e4553b4724'
 
-We also need to generate a header file for the public key to be included in the firmware
-that will be programed in the device.
-
-In examples/suit_update:
-
-    $ BOARD=samr21-xpro make suit/keyhdr
-
-You will get this message in the terminal:
-
-    xxd -i public.key > public_key.h
-
+This also generates the `public_key.h` that will be included in the built firmware.
 
 ## Standalone node Using Ethos
 

--- a/makefiles/suit.v4.inc.mk
+++ b/makefiles/suit.v4.inc.mk
@@ -20,8 +20,13 @@ SUIT_KEY ?= secret.key
 SUIT_PUB ?= public.key
 SUIT_PUB_HDR ?= public_key.h
 
-$(SUIT_PUB_HDR):
-	xxd -i $(SUIT_PUB) > $@
+$(SUIT_KEY) $(SUIT_PUB):
+	@$(RIOTBASE)/dist/tools/suit_v4/gen_key.py
+
+$(SUIT_PUB_HDR): $(SUIT_PUB)
+	@xxd -i $(SUIT_PUB) > $@
+
+suit/genkey: $(SUIT_KEY) $(SUIT_PUB) $(SUIT_PUB_HDR)
 
 $(SUIT_MANIFEST): $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
 	$(RIOTBASE)/dist/tools/suit_v4/gen_manifest.py \
@@ -64,8 +69,3 @@ suit/notify: | $(filter suit/publish, $(MAKECMDGOALS))
 	aiocoap-client -m POST "coap://$(SUIT_CLIENT)/suit/trigger" \
 		--payload "$(SUIT_COAP_ROOT)/$$(basename $(SUIT_MANIFEST_SIGNED_LATEST))" && \
 		echo "Triggered $(SUIT_CLIENT) to update."
-
-suit/genkey:
-	$(RIOTBASE)/dist/tools/suit_v4/gen_key.py
-
-suit/keyhdr: suit/genkey $(SUIT_PUB_HDR)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR improves the `suit/genkeys` and remove the useless `suit/genhdr` target.

Now all files (secret.key, public.key and public_key.hà are generated with one call to `make suit/genkeys`. This is much more simpler to use.

The `examples/suit_update` README has been updated.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try `make BOARD=samr21-xpro -C examples/suit_update suit/genkeys`

And verify all 3 key files are generated.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
