### PR TITLE
suit: rework key handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,4 @@ scan-build/
 results/
 
 # suit manifest keys
-secret.key
-public.key
-public_key.h
+keys/

--- a/dist/tools/suit_v4/gen_key.py
+++ b/dist/tools/suit_v4/gen_key.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import ed25519
+import sys
 signing_key, verifying_key = ed25519.create_keypair()
-open("secret.key", "wb").write(signing_key.to_bytes())
+open(sys.argv[1], "wb").write(signing_key.to_bytes())
 vkey_hex = verifying_key.to_ascii(encoding="hex")
-open("public.key", "wb").write(verifying_key.to_bytes())
+open(sys.argv[2], "wb").write(verifying_key.to_bytes())
 print("the public key is", vkey_hex)

--- a/makefiles/suit.v4.inc.mk
+++ b/makefiles/suit.v4.inc.mk
@@ -16,18 +16,39 @@ export CFLAGS += -DSOCK_URLPATH_MAXLEN=128
 SUIT_VENDOR ?= "riot-os.org"
 SUIT_SEQNR ?= $(APP_VER)
 SUIT_DEVICE_ID ?= $(BOARD)
-SUIT_KEY ?= secret.key
-SUIT_PUB ?= public.key
-SUIT_PUB_HDR ?= public_key.h
+
+#
+# SUIT encryption keys
+#
+ifeq (1, $(RIOT_CI_BUILD))
+  SUIT_KEY_DIR ?= $(BINDIR)
+else
+  SUIT_KEY_DIR ?= $(RIOTBASE)/keys
+endif
+
+SUIT_KEY ?= $(SUIT_KEY_DIR)/secret.key
+SUIT_PUB ?= $(SUIT_KEY_DIR)/public.key
+
+SUIT_PUB_HDR = $(BINDIR)/riotbuild/public_key.h
+SUIT_PUB_HDR_DIR = $(dir $(SUIT_PUB_HDR))
+CFLAGS += -I$(SUIT_PUB_HDR_DIR)
+BUILDDEPS += $(SUIT_PUB_HDR)
 
 $(SUIT_KEY) $(SUIT_PUB):
+	@echo suit: generating key pair in $(SUIT_KEY_DIR)
+	@mkdir -p $(SUIT_KEY_DIR)
 	@$(RIOTBASE)/dist/tools/suit_v4/gen_key.py $(SUIT_KEY) $(SUIT_PUB)
 
 $(SUIT_PUB_HDR): $(SUIT_PUB)
-	@xxd -i $(SUIT_PUB) > $@
+	@mkdir -p $(SUIT_PUB_HDR_DIR)
+	@cd $(dir $(SUIT_PUB)) && xxd -i $(notdir $(SUIT_PUB)) > $@
 
-suit/genkey: $(SUIT_KEY) $(SUIT_PUB) $(SUIT_PUB_HDR)
+suit/genkey: $(SUIT_KEY) $(SUIT_PUB)
 
+suit/delkeys:
+	rm -f $(SUIT_KEY) $(SUIT_PUB)
+
+#
 $(SUIT_MANIFEST): $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
 	$(RIOTBASE)/dist/tools/suit_v4/gen_manifest.py \
 	  --template $(RIOTBASE)/dist/tools/suit_v4/test-2img.json \

--- a/makefiles/suit.v4.inc.mk
+++ b/makefiles/suit.v4.inc.mk
@@ -20,33 +20,44 @@ SUIT_DEVICE_ID ?= $(BOARD)
 #
 # SUIT encryption keys
 #
+
+# Specify key to use.
+# Will use $(SUIT_KEY_DIR)/$(SUIT_KEY) $(SUIT_KEY_DIR)/$(SUIT_KEY).pub as
+# private/public key files, similar to how ssh names its key files.
+SUIT_KEY ?= default
+
 ifeq (1, $(RIOT_CI_BUILD))
   SUIT_KEY_DIR ?= $(BINDIR)
 else
   SUIT_KEY_DIR ?= $(RIOTBASE)/keys
 endif
 
-SUIT_KEY ?= $(SUIT_KEY_DIR)/secret.key
-SUIT_PUB ?= $(SUIT_KEY_DIR)/public.key
+SUIT_SEC ?= $(SUIT_KEY_DIR)/$(SUIT_KEY)
+SUIT_PUB ?= $(SUIT_KEY_DIR)/$(SUIT_KEY).pub
 
 SUIT_PUB_HDR = $(BINDIR)/riotbuild/public_key.h
 SUIT_PUB_HDR_DIR = $(dir $(SUIT_PUB_HDR))
 CFLAGS += -I$(SUIT_PUB_HDR_DIR)
 BUILDDEPS += $(SUIT_PUB_HDR)
 
-$(SUIT_KEY) $(SUIT_PUB):
+$(SUIT_SEC) $(SUIT_PUB):
 	@echo suit: generating key pair in $(SUIT_KEY_DIR)
 	@mkdir -p $(SUIT_KEY_DIR)
-	@$(RIOTBASE)/dist/tools/suit_v4/gen_key.py $(SUIT_KEY) $(SUIT_PUB)
+	@$(RIOTBASE)/dist/tools/suit_v4/gen_key.py $(SUIT_SEC) $(SUIT_PUB)
 
-$(SUIT_PUB_HDR): $(SUIT_PUB)
+# set FORCE so switching between keys using "SUIT_KEY=foo make ..."
+# triggers a rebuild even if the new key would otherwise not (because the other
+# key's mtime is too far back).
+$(SUIT_PUB_HDR): $(SUIT_PUB) FORCE
 	@mkdir -p $(SUIT_PUB_HDR_DIR)
-	@cd $(dir $(SUIT_PUB)) && xxd -i $(notdir $(SUIT_PUB)) > $@
+	@cp $(SUIT_PUB) $(SUIT_PUB_HDR_DIR)/public.key
+	@cd $(SUIT_PUB_HDR_DIR) && xxd -i public.key \
+	  | '$(LAZYSPONGE)' $(LAZYSPONGE_FLAGS) '$@'
 
-suit/genkey: $(SUIT_KEY) $(SUIT_PUB)
+suit/genkey: $(SUIT_SEC) $(SUIT_PUB)
 
 suit/delkeys:
-	rm -f $(SUIT_KEY) $(SUIT_PUB)
+	rm -f $(SUIT_SEC) $(SUIT_PUB)
 
 #
 $(SUIT_MANIFEST): $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
@@ -62,7 +73,7 @@ $(SUIT_MANIFEST): $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
 
 $(SUIT_MANIFEST_SIGNED): $(SUIT_MANIFEST)
 	$(RIOTBASE)/dist/tools/suit_v4/sign-04.py \
-	  $(SUIT_KEY) $(SUIT_PUB) $< $@
+	  $(SUIT_SEC) $(SUIT_PUB) $< $@
 
 $(SUIT_MANIFEST_LATEST): $(SUIT_MANIFEST)
 	@ln -f -s $< $@

--- a/makefiles/suit.v4.inc.mk
+++ b/makefiles/suit.v4.inc.mk
@@ -21,7 +21,7 @@ SUIT_PUB ?= public.key
 SUIT_PUB_HDR ?= public_key.h
 
 $(SUIT_KEY) $(SUIT_PUB):
-	@$(RIOTBASE)/dist/tools/suit_v4/gen_key.py
+	@$(RIOTBASE)/dist/tools/suit_v4/gen_key.py $(SUIT_KEY) $(SUIT_PUB)
 
 $(SUIT_PUB_HDR): $(SUIT_PUB)
 	@xxd -i $(SUIT_PUB) > $@


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR does the following:

1. update the gen_keys.py for suit so it doesn't always write to the current folder
2. make suit use a SUIT_KEY_DIR variable, which defaults to ```$(RIOTBASE)/keys``` and ```$(BINDIR)``` for CI builds
3. creates the SUIT_KEY_HDR in ```$(BINDIR)/riotbuild``` and adds the necessary include path to CFLAGS
4. fixes up some of the key dependencies
5. obsoletes the "suit/keyhdr" target

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try suit workflow and suit related make targets...

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
