### PR TITLE
examples/suit_update: cleanup README

### DIFF
--- a/examples/suit_update/README.md
+++ b/examples/suit_update/README.md
@@ -24,7 +24,7 @@ Table of contents:
 
 ## Prerequisites
 [prerequisites]: #Prerequisites
-    
+
 - Install python dependencies (only Python3.6 and later is supported):
 
       $ sudo pip install ed25519 pyasn1 cbor click

--- a/examples/suit_update/README.md
+++ b/examples/suit_update/README.md
@@ -9,7 +9,6 @@ Table of contents:
 
 - [Prerequisites][prerequisites]
 - [Setup][setup]
-  - [Sign key generation][key-generation]
   - [Setup a wired device using ethos][setup-wired]
     - [Provision the device][setup-wired-provision]
     - [Configure the network][setup-wired-network]
@@ -52,21 +51,6 @@ Table of contents:
 ## Setup
 [setup]: #Setup
 
-### Key Generation
-[key-generation]: #Key-generation
-
-To sign the manifest and for de the device to verify the manifest a key must be generated.
-
-Simply use the `suit/genkey` make target:
-
-    $ BOARD=samr21-xpro make -C examples/suit_update suit/genkey
-
-You will get this message in the terminal:
-
-    the public key is b'a0fc7fe714d0c81edccc50c9e3d9e6f9c72cc68c28990f235ede38e4553b4724'
-
-This also generates the `public_key.h` that will be included in the built firmware.
-
 ### Setup a wired device using ethos
 [setup-wired]: #Setup-a-wired-device-using-ethos
 
@@ -76,6 +60,10 @@ This also generates the `public_key.h` that will be included in the built firmwa
 In order to get a SUIT capable firmware onto the node. In examples/suit_update:
 
     $ BOARD=samr21-xpro make -C examples/suit_update clean riotboot/flash -j4
+
+This command also generates the cryptographic keys (private/public) used to
+sign and verify the manifest and images. See the "Key generation" section in
+[SUIT detailed explanation][detailed-explanation] for details.
 
 #### Configure the network
 [setup-wired-network]: #Configure-the-network
@@ -403,6 +391,20 @@ It will then fetch the firmware, write it to the inactive slot and reboot the de
 Digest validation is done once all the firmware is written to flash.
 From there the bootloader takes over, verifying the slot riotboot_hdr and boots
 from the newest image.
+
+#### Key Generation
+
+To sign the manifest and for the device to verify the manifest a pair of keys
+must be generated. Note that this is done automatically when building an
+updatable RIOT image with `riotboot` or `suit/publish` make targets.
+
+This is simply done using the `suit/genkey` make target:
+
+    $ BOARD=samr21-xpro make -C examples/suit_update suit/genkey
+
+You will get this message in the terminal:
+
+    Generated public key: 'a0fc7fe714d0c81edccc50c9e3d9e6f9c72cc68c28990f235ede38e4553b4724'
 
 ### Network
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is removing some occurrences of `suit/genkey` usage since it's now done implicitly when building a new image.

It also removes a trailing whitespace in the README (found while running make static-test)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Read the document also verify that the trailing whitespaces are gone.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
