### PR TITLE
tools/suit_v4/gen_key: cleanup and improve Python script

### DIFF
--- a/dist/tools/suit_v4/gen_key.py
+++ b/dist/tools/suit_v4/gen_key.py
@@ -1,9 +1,24 @@
 #!/usr/bin/env python3
 
-import ed25519
 import sys
-signing_key, verifying_key = ed25519.create_keypair()
-open(sys.argv[1], "wb").write(signing_key.to_bytes())
-vkey_hex = verifying_key.to_ascii(encoding="hex")
-open(sys.argv[2], "wb").write(verifying_key.to_bytes())
-print("the public key is", vkey_hex)
+import ed25519
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: gen_key.py <secret filename> <public filename>")
+        sys.exit(1)
+
+    _signing_key, _verifying_key = ed25519.create_keypair()
+    with open(sys.argv[1], "wb") as f:
+        f.write(_signing_key.to_bytes())
+
+    with open(sys.argv[2], "wb") as f:
+        f.write(_verifying_key.to_bytes())
+
+    vkey_hex = _verifying_key.to_ascii(encoding="hex")
+    print("Generated public key: '{}'".format(vkey_hex.decode()))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is cleanup the `gen_key.py` used by the suit_v4 workflow to generate the signing/verifying keys.

It fixes some pep8, restructure the script and make the output a bit better. There's also a basic verification of input arguments.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make static-test` should not report any error on this file.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
