### PR TITLE
suit: fix errors reported by ccpcheck

### DIFF
--- a/sys/suit/coap.c
+++ b/sys/suit/coap.c
@@ -327,7 +327,7 @@ static void _suit_handle_url(const char *url)
         manifest.urlbuf = _url;
         manifest.urlbuf_len = SUIT_URL_MAX;
 
-        ssize_t res;
+        int res;
         if ((res = suit_v4_parse(&manifest, _manifest_buf, size)) != SUIT_OK) {
             printf("suit_v4_parse() failed. res=%i\n", res);
             return;

--- a/sys/suit/v4/handlers.c
+++ b/sys/suit/v4/handlers.c
@@ -43,10 +43,9 @@ static int _hello_handler(suit_v4_manifest_t *manifest, int key, CborValue *it)
     (void)manifest;
     (void)key;
 
-    char buf[HELLO_HANDLER_MAX_STRLEN];
-    size_t len = HELLO_HANDLER_MAX_STRLEN;
-
     if (cbor_value_is_text_string(it)) {
+        size_t len = HELLO_HANDLER_MAX_STRLEN;
+        char buf[HELLO_HANDLER_MAX_STRLEN];
         cbor_value_copy_text_string(it, buf, &len, NULL);
         return SUIT_OK;
     }

--- a/sys/suit/v4/handlers.c
+++ b/sys/suit/v4/handlers.c
@@ -306,8 +306,8 @@ static int _version_handler(suit_v4_manifest_t *manifest, int key,
         (cbor_value_get_int(it, &version) == CborNoError)) {
         if (version == SUIT_VERSION) {
             manifest->validated |= SUIT_VALIDATED_VERSION;
-            return 0;
             LOG_INFO("suit: validated manifest version\n)");
+            return 0;
         }
         else {
             return -1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing 3 errors reported by ccpcheck (e.g. when running make statis-test):
- in handlers.c: the scope of some variables could be reduced: a2364ac
- in handlers.c: there was an unreachable logging statement: aa9e582
- in coap.c: a return value was declared as `ssize_t` although all functions called has int as return value. This was causing a portability error when ret is used in a printf function.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- SUIT workflow should still work
- no ccpcheck errors are raises by `make static-test`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
