### PR TITLE
sys/riotboot: document flashwrite image digest verification

### DIFF
--- a/sys/include/riotboot/flashwrite.h
+++ b/sys/include/riotboot/flashwrite.h
@@ -169,7 +169,19 @@ static inline int riotboot_flashwrite_finish(riotboot_flashwrite_t *state)
  */
 size_t riotboot_flashwrite_slotsize(const riotboot_flashwrite_t *state);
 
-int riotboot_flashwrite_verify_sha256(const uint8_t *sha256_digest, size_t img_size, int target_slot);
+/**
+ * @brief       Verify the digest of an image
+ *
+ * @param[in]   sha256_digest   content of the image digest
+ * @param[in]   img_size        the size of the image
+ * @param[in]   target_slot     the image slot number
+ *
+ * @returns     -1 when image is too small
+ * @returns     0 if the digest is valid
+ * @returns     1 if the digest is invalid
+ */
+int riotboot_flashwrite_verify_sha256(const uint8_t *sha256_digest,
+                                      size_t img_size, int target_slot);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the missing documentation of `riotboot_flashwrite_verify_sha256` function in riotboot.

I'm not sure of the wording so better suggestions are welcome.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make static-test` should not return any doxygen error regarding `riotboot/flashwrite.h`.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
