### PR TITLE
suit: add missing doxygen documentation to suit

### DIFF
--- a/sys/include/suit/v4/suit.h
+++ b/sys/include/suit/v4/suit.h
@@ -148,8 +148,9 @@ int suit_v4_parse(suit_v4_manifest_t *manifest, const uint8_t *buf, size_t len);
 
 int suit_v4_policy_check(suit_v4_manifest_t *manifest);
 
-int cbor_map_iterate_init(CborValue *map, CborValue *it);
-int cbor_map_iterate(CborValue *map, CborValue *key, CborValue *value);
+
+int suit_cbor_map_iterate_init(CborValue *map, CborValue *it);
+int suit_cbor_map_iterate(CborValue *map, CborValue *key, CborValue *value);
 
 int suit_cbor_get_int(const CborValue *key, int *out);
 int suit_cbor_get_uint(const CborValue *key, unsigned *out);

--- a/sys/suit/coap.c
+++ b/sys/suit/coap.c
@@ -368,7 +368,7 @@ static void _suit_handle_url(const char *url)
 }
 
 int suit_flashwrite_helper(void *arg, size_t offset, uint8_t *buf, size_t len,
-                    int more)
+                           int more)
 {
     riotboot_flashwrite_t *writer = arg;
 

--- a/sys/suit/v4/cbor.c
+++ b/sys/suit/v4/cbor.c
@@ -88,13 +88,13 @@ int suit_cbor_get_int(const CborValue *it, int *out)
 int suit_cbor_get_string(const CborValue *it, const uint8_t **buf, size_t *len)
 {
     if (!(cbor_value_is_text_string(it) || cbor_value_is_byte_string(it) || cbor_value_is_length_known(it))) {
-        return -1;
+        return SUIT_ERR_INVALID_MANIFEST;
     }
     CborValue next = *it;
     cbor_value_get_string_length(it, len);
     cbor_value_advance(&next);
     *buf = next.ptr - *len;
-    return 0;
+    return SUIT_OK;
 }
 
 int suit_cbor_get_uint32(const CborValue *it, uint32_t *out)

--- a/sys/suit/v4/cbor.c
+++ b/sys/suit/v4/cbor.c
@@ -40,7 +40,7 @@
 static suit_manifest_handler_t _manifest_get_auth_wrapper_handler(int key);
 typedef suit_manifest_handler_t (*suit_manifest_handler_getter_t)(int key);
 
-int cbor_map_iterate_init(CborValue *map, CborValue *it)
+int suit_cbor_map_iterate_init(CborValue *map, CborValue *it)
 {
     if (!cbor_value_is_map(map)) {
         LOG_INFO("suit_v4_parse(): manifest not an map\n)");
@@ -52,7 +52,7 @@ int cbor_map_iterate_init(CborValue *map, CborValue *it)
     return SUIT_OK;
 }
 
-int cbor_map_iterate(CborValue *it, CborValue *key, CborValue *value)
+int suit_cbor_map_iterate(CborValue *it, CborValue *key, CborValue *value)
 {
     if (cbor_value_at_end(it)) {
         return 0;
@@ -155,14 +155,14 @@ static int _v4_parse(suit_v4_manifest_t *manifest, const uint8_t *buf,
 
     map = it;
 
-    if (cbor_map_iterate_init(&map, &it) != SUIT_OK) {
+    if (suit_cbor_map_iterate_init(&map, &it) != SUIT_OK) {
         LOG_DEBUG("manifest not map!\n");
         return SUIT_ERR_INVALID_MANIFEST;
     }
 
     LOG_DEBUG("jumping into map\n)");
 
-    while (cbor_map_iterate(&it, &key, &value)) {
+    while (suit_cbor_map_iterate(&it, &key, &value)) {
         int integer_key;
         if (suit_cbor_get_int(&key, &integer_key) != SUIT_OK){
             return SUIT_ERR_INVALID_MANIFEST;

--- a/sys/suit/v4/handlers.c
+++ b/sys/suit/v4/handlers.c
@@ -386,11 +386,11 @@ static int _component_handler(suit_v4_manifest_t *manifest, int key,
             return SUIT_ERR_INVALID_MANIFEST;
         }
 
-        cbor_map_iterate_init(&arr, &map);
+        suit_cbor_map_iterate_init(&arr, &map);
 
         suit_v4_component_t *current = &manifest->components[n];
 
-        while (cbor_map_iterate(&map, &key, &value)) {
+        while (suit_cbor_map_iterate(&map, &key, &value)) {
             // handle key, value
             int integer_key;
             if (suit_cbor_get_int(&key, &integer_key)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is adding the missing doxygen to the `suit.h` file. Some return code are also updated to consistency and some cbor related function were also renamed, still for consistency.

Documentation rewording/improvement suggestions are welcome.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- `make static-test` should not return doxygen error related to suit.h
- the suit workflow is working

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
