### PR TITLE
tools/suit_v4: fix flake8 issues in gen_manifest script

### DIFF
--- a/dist/tools/suit_v4/gen_manifest.py
+++ b/dist/tools/suit_v4/gen_manifest.py
@@ -56,15 +56,16 @@ def main(template, urlroot, offsets, slotfiles, output, seqnr, uuid_vendor,
         uri = os.path.join(urlroot, os.path.basename(filename))
         offset = offsets[slot]
 
-        template["components"][0]["images"][slot].update({
+        _image_slot = template["components"][0]["images"][slot]
+        _image_slot.update({
             "file": filename,
             "uri": uri,
             "size": size,
             "digest": sha256_from_file(slotfile),
             })
 
-        template["components"][0]["images"][slot]["conditions"][0]["condition-component-offset"] = offset
-        template["components"][0]["images"][slot]["file"] = filename
+        _image_slot["conditions"][0]["condition-component-offset"] = offset
+        _image_slot["file"] = filename
 
     result = compile_to_suit(template)
     if output:

--- a/dist/tools/suit_v4/gen_manifest.py
+++ b/dist/tools/suit_v4/gen_manifest.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
-import click
-import hashlib
 import os
-import sys
+import hashlib
 import json
 import uuid
+
+import click
+
 from suit_manifest_encoder_04 import compile_to_suit
+
 
 def str2int(x):
     if x.startswith("0x"):
@@ -14,10 +16,12 @@ def str2int(x):
     else:
         return x
 
+
 def sha256_from_file(filepath):
     sha256 = hashlib.sha256()
     sha256.update(open(filepath, "rb").read())
     return sha256.digest()
+
 
 @click.command()
 @click.option("--template", "-t", required=True, type=click.File())
@@ -29,7 +33,8 @@ def sha256_from_file(filepath):
 @click.option("--uuid-class", "-C",  required=True)
 @click.option("--keyfile", "-K",  required=False, type=click.File())
 @click.argument("slotfiles", nargs=2, type=click.Path())
-def main(template, urlroot, offsets, slotfiles, output, seqnr, uuid_vendor, uuid_class, keyfile):
+def main(template, urlroot, offsets, slotfiles, output, seqnr, uuid_vendor,
+         uuid_class, keyfile):
 
     uuid_vendor = uuid.uuid5(uuid.NAMESPACE_DNS, uuid_vendor)
     uuid_class = uuid.uuid5(uuid_vendor, uuid_class)
@@ -38,12 +43,12 @@ def main(template, urlroot, offsets, slotfiles, output, seqnr, uuid_vendor, uuid
 
     template["sequence-number"] = seqnr
     template["conditions"] = [
-            { "condition-vendor-id" : uuid_vendor.hex },
-            {  "condition-class-id" : uuid_class.hex },
+            {"condition-vendor-id": uuid_vendor.hex},
+            {"condition-class-id": uuid_class.hex},
         ]
 
     offsets = offsets.split(",")
-    offsets = [ str2int(x) for x in offsets ]
+    offsets = [str2int(x) for x in offsets]
 
     for slot, slotfile in enumerate(slotfiles):
         filename = slotfile
@@ -54,8 +59,8 @@ def main(template, urlroot, offsets, slotfiles, output, seqnr, uuid_vendor, uuid
         template["components"][0]["images"][slot].update({
             "file": filename,
             "uri": uri,
-            "size" : size,
-            "digest" : sha256_from_file(slotfile),
+            "size": size,
+            "digest": sha256_from_file(slotfile),
             })
 
         template["components"][0]["images"][slot]["conditions"][0]["condition-component-offset"] = offset
@@ -68,5 +73,5 @@ def main(template, urlroot, offsets, slotfiles, output, seqnr, uuid_vendor, uuid
         print(result)
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes flake8 issues raised by make static-test on `gen_manifest.py`.

In a follow-up PR, I'd also like to drop the dependency to the click module (although I like the tool) because it's adding another python dependency to the workflow and the Python standard library already provide what's needed, e.g. argparse, to parse command line arguments.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- `make static-test` doesn't report flake8 issues on gen_manifest.py
- the SUIT workflow still works

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
