### PR TITLE
tools/suit_v4: disable flake8 checks on suit_manifest_encoder script

### DIFF
--- a/dist/tools/flake8/check.sh
+++ b/dist/tools/flake8/check.sh
@@ -23,7 +23,12 @@ cd $RIOTBASE
 : "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
 . "${RIOTTOOLS}"/ci/changed_files.sh
 
-EXCLUDE='^(.+/vendor/|dist/tools/cc2538-bsl|dist/tools/mcuboot|dist/tools/uhcpd|dist/tools/stm32loader)'
+EXCLUDE="^(.+/vendor/\
+|dist/tools/cc2538-bsl\
+|dist/tools/mcuboot\
+|dist/tools/uhcpd\
+|dist/tools/stm32loader\
+|dist/tools/suit_v4/suit_manifest_encoder_04)"
 FILEREGEX='(\.py$|pyterm$)'
 FILES=$(FILEREGEX=${FILEREGEX} EXCLUDE=${EXCLUDE} changed_files)
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is excluding the `suit_manifest_encoder_script` from flake8 checks because there are too many problems and because this file is 90% external code.

While digging a bit more, it seems this file is mix between ARM code and our code. Maybe some refactoring is worth before contributing this upstream otherwise it will become difficult to maintain in the long run when SUIT specs will evolve.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- `make static-test` doesn't report anymore errors related to this script
- SUIT workflow still works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
